### PR TITLE
Individual parameters for the password hashing algorithm for each user

### DIFF
--- a/app/app-config.js.example
+++ b/app/app-config.js.example
@@ -18,11 +18,6 @@ angular.module('hdbApp')
             'database': {
                 'name': "dev",
                 'remote_url': "http://demo-db.sinnfragen.org/db/"
-            },
-            'crypto': {
-                'salt': "helgo_db",
-                'iterations': 128,
-                'keysize': 256/32
             }
         };
     });

--- a/app/scripts/services/user.js
+++ b/app/scripts/services/user.js
@@ -25,8 +25,11 @@ angular.module('hdbApp')
 
         User.prototype = angular.extend({}, AbstractModel, {
             authenticate: function (password) {
-                return (CryptoJS.PBKDF2(password, appConfig.crypto.salt,
-                    {keySize: appConfig.crypto.keysize, iterations: appConfig.crypto.iterations}) == this.password);
+                return (CryptoJS.PBKDF2(password, this.password.salt,
+                    {
+                        keySize: this.password.keysize,
+                        iterations: this.password.iterations
+                    }).toString() === this.password.hash);
             },
         });
 

--- a/app/scripts/services/usermanager.js
+++ b/app/scripts/services/usermanager.js
@@ -61,8 +61,8 @@ angular.module('hdbApp')
                         // renew login with updated credentials
                         appDB.login(user.name, newPassword);
 
-                        user.password = "" + CryptoJS.PBKDF2(newPassword, appConfig.crypto.salt, //TODO: newPassword instead password?!?
-                            {keySize: appConfig.crypto.keysize, iterations: appConfig.crypto.iterations});
+                        user.password.hash = "" + CryptoJS.PBKDF2(newPassword, user.password.salt,
+                                {keySize: user.password.keysize, iterations: user.password.iterations});
                         user.update().then(
                             function () {
                                 $log.debug("Changed local password");


### PR DESCRIPTION
New structure of a password entry for the users:

``` json
  "password": {
    "hash": "<resulting password hash>",
    "salt": "<individual user salt>",
    "iterations": "<iterations of the hash function>",
    "keysize": "<hash length in bytes>"
  }
```
Can be tested with the user `BigUser` and Passsword `ppp9`. 

- [x] The script for the user creation has to be adapted to this and must generate the random salts.
- [x] The password section in the `app-config.sample.js` should be removed